### PR TITLE
Feat/#53/mini quiz

### DIFF
--- a/src/components/buttons/BlueButton.jsx
+++ b/src/components/buttons/BlueButton.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import '@/styles/global.css';
 
 function BlueButton({ value, styles, onClickFunc, disabled = false }) {
   return (
     <button
       onClick={onClickFunc}
       // text-detail and padding have to be fixed, 인자로 추가할까??
-      className={`${styles} ${disabled ? 'opacity-30' : 'opacity-100 hover:scale-105 transition-transform'} flex items-center justify-center rounded-full bg-primary-blue text-neutral-white`}
+      className={`${styles} ${disabled ? 'opacity-30' : 'opacity-100 hover:scale-105 transition-transform'} set-center rounded-full bg-primary-blue text-neutral-white`}
     >
       {value}
     </button>

--- a/src/components/buttons/BluePurpleButton.jsx
+++ b/src/components/buttons/BluePurpleButton.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import '@/styles/global';
 
 function BluePurpleButton({ value, onClickFunc, styles, disabled = false }) {
   return (
     <button
       onClick={onClickFunc}
-      className={`${styles} ${disabled ? 'opacity-30' : 'opacity-100 hover:scale-105 transition-transform'} flex items-center justify-center rounded-full bg-gradient-blue-purple  text-neutral-white`}
+      className={`${styles} ${disabled ? 'opacity-30' : 'opacity-100 hover:scale-105 transition-transform'} set-center rounded-full bg-gradient-blue-purple  text-neutral-white`}
       disabled={disabled}
     >
       {value}

--- a/src/components/buttons/BluePurpleButton.jsx
+++ b/src/components/buttons/BluePurpleButton.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import '@/styles/global';
+import '@/styles/global.css';
 
 function BluePurpleButton({ value, onClickFunc, styles, disabled = false }) {
   return (

--- a/src/components/buttons/WhiteButton.jsx
+++ b/src/components/buttons/WhiteButton.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import '@/styles/global.css';
 
 function WhiteButton({ value, onClickFunc, styles, disabled = false }) {
   return (
     <button
       onClick={onClickFunc}
-      className={`${styles} ${disabled ? 'opacity-30' : 'opacity-100 hover:scale-105 transition-transform'} flex items-center justify-center rounded-full bg-neutral-white text-neutral-black`}
+      className={`${styles} ${disabled ? 'opacity-30' : 'opacity-100 hover:scale-105 transition-transform'} set-center rounded-full bg-neutral-white text-neutral-black`}
       disabled={disabled}
     >
       {value}

--- a/src/components/modal/GetCarModal.jsx
+++ b/src/components/modal/GetCarModal.jsx
@@ -6,7 +6,7 @@ import '@/styles/global.css';
 
 function GetItemModal(close) {
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-opacity-50 bg-neutral-black z-[100]">
+    <div className="fixed inset-0 set-center bg-opacity-50 bg-neutral-black z-[100]">
       <div className="bg-neutral-white w-[600px] h-[480px] py-1500 flex flex-col items-center relative rounded-[20px]">
         <button onClick={close} className="absolute top-[29px] right-[29px]">
           <img src={modalClose} alt="Close" />

--- a/src/constants/newCarIntro/newCarDetailData.jsx
+++ b/src/constants/newCarIntro/newCarDetailData.jsx
@@ -7,31 +7,37 @@ import image6 from '@/assets/images/newCarDetailImage6.svg';
 
 const newCarDetailData = [
   {
+    id: 1,
     title: '실내/외 V2L (Vehicle to Load)',
     description: '야외/실내에서 자유로운 전자기기 사용',
     imageSrc: image1,
   },
   {
+    id: 2,
     title: '넓은 2열 공간',
     description: '길어진 휠 베이스',
     imageSrc: image2,
   },
   {
+    id: 3,
     title: '클러스터 & 내비게이션',
     description: '더 커진 10.25인치 화면',
     imageSrc: image3,
   },
   {
+    id: 4,
     title: '고속도로 주행 보조',
     description: '장거리 고속도로 운전도 편안하게',
     imageSrc: image4,
   },
   {
+    id: 5,
     title: '서라운드 뷰 모니터',
     description: '좁은 길을 지날 때, 주차할 때',
     imageSrc: image5,
   },
   {
+    id: 6,
     title: '스마트폰 무선 충전',
     description: 'USB 연결 없이',
     imageSrc: image6,

--- a/src/pages/joinEvent/Card1.jsx
+++ b/src/pages/joinEvent/Card1.jsx
@@ -1,9 +1,10 @@
-import React ,{useContext} from 'react';
+import React, { useContext } from 'react';
 import noCarImage from '@/assets/images/noCarImage.svg';
 import carImage from '@/assets/images/carImage.svg';
 import BlueButton from '@/components/buttons/BlueButton';
 import questionMark from '@/assets/images/questionMark.svg';
 import { AuthContext } from '@/context/authContext';
+import '@/styles/global.css';
 
 function Card1() {
   const { userInfo } = useContext(AuthContext);
@@ -34,9 +35,7 @@ function Card1() {
           ></img>
         )}
       </div>
-      <div
-        className={`flex items-center justify-center ${haveCar ? 'invisible' : 'visible'}`}
-      >
+      <div className={`set-center ${haveCar ? 'invisible' : 'visible'}`}>
         <BlueButton
           value="자동차 얻기 "
           onClickFunc={() => alert('자동차 얻기')}

--- a/src/pages/joinEvent/Card1.jsx
+++ b/src/pages/joinEvent/Card1.jsx
@@ -1,12 +1,20 @@
-import React from 'react';
+import React ,{useContext} from 'react';
 import noCarImage from '@/assets/images/noCarImage.svg';
 import carImage from '@/assets/images/carImage.svg';
 import BlueButton from '@/components/buttons/BlueButton';
 import questionMark from '@/assets/images/questionMark.svg';
-import PropTypes from 'prop-types';
+import { AuthContext } from '@/context/authContext';
 
-function Card1({ haveCar }) {
-  const imageSrc = haveCar ? carImage : noCarImage;
+function Card1() {
+  const { userInfo } = useContext(AuthContext);
+  const { haveCar } = userInfo;
+
+  // haveCar 값이 바뀔 때는 어차피 useContext로 재랜더링이 되므로 let으로 선언 아래의 공식 문서에도 let 사용하는 예시가 있음!
+  // https://react.dev/learn/preserving-and-resetting-state
+  let imageSrc = noCarImage;
+  if (haveCar) {
+    imageSrc = carImage;
+  }
 
   return (
     <div className="flex flex-col justify-between bg-card1 px-800 pt-700 pb-500 w-[320px] h-[417px] rounded-[30px]">
@@ -38,10 +46,5 @@ function Card1({ haveCar }) {
     </div>
   );
 }
-
-Card1.propTypes = {
-  // eslint 속이기 위한 data 타입
-  haveCar: PropTypes.bool.isRequired,
-};
 
 export default Card1;

--- a/src/pages/joinEvent/Card2.jsx
+++ b/src/pages/joinEvent/Card2.jsx
@@ -5,6 +5,7 @@ import toolBoxImage from '@/assets/images/toolBoxImage.svg';
 import questionMark from '@/assets/images/questionMark.svg';
 import { AuthContext } from '@/context/authContext';
 import { useNavigate } from 'react-router-dom';
+import '@/styles/global.css';
 
 function Card2() {
   const navigate = useNavigate();
@@ -48,9 +49,7 @@ function Card2() {
           ></img>
         )}
       </div>
-      <div
-        className={`flex items-center justify-center ${joinedQuiz ? 'invisible' : 'visible'}`}
-      >
+      <div className={`set-center ${joinedQuiz ? 'invisible' : 'visible'}`}>
         <BlueButton
           value="도구 얻기"
           onClickFunc={gotoMiniQuiz}

--- a/src/pages/joinEvent/Card2.jsx
+++ b/src/pages/joinEvent/Card2.jsx
@@ -1,17 +1,20 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import BlueButton from '@/components/buttons/BlueButton';
 import noToolBoxImage from '@/assets/images/noToolBoxImage.svg';
 import toolBoxImage from '@/assets/images/toolBoxImage.svg';
 import questionMark from '@/assets/images/questionMark.svg';
-import PropTypes from 'prop-types';
+import { AuthContext } from '@/context/authContext';
 
-function Card2({ toolBoxCnt, auth, joined }) {
+function Card2() {
+  const { userInfo } = useContext(AuthContext);
+  const { toolBoxCnt, joinedQuiz } = userInfo;
   let imageSrc = noToolBoxImage;
-
   //QuizJoined 했으면 상품 받음
+  //Card1에 있는 주석 참고!
   if (joined) {
     imageSrc = toolBoxImage;
   }
+
   return (
     <div className="flex flex-col justify-between bg-card2 px-800 pt-700 pb-500 h-[417px] w-[320px] rounded-[30px]">
       <div className="text-detail-2-semibold text-primary-blue h-800">
@@ -20,7 +23,7 @@ function Card2({ toolBoxCnt, auth, joined }) {
       <div className="text-detail-1-semibold h-1800 text-neutral-black">
         일일 미니퀴즈
         <div
-          className={`items-center justify-end h-900 flex ${auth ? 'visible' : 'invisible'}`}
+          className={`items-center justify-end h-900 flex ${toolBoxCnt !== undefined ? 'visible' : 'invisible'}`}
         >
           <div
             className={`px-400 py-100 rounded-[8px] text-detail-3-semibold text-primary-blue bg-neutral-white`}
@@ -40,7 +43,7 @@ function Card2({ toolBoxCnt, auth, joined }) {
         )}
       </div>
       <div
-        className={`flex items-center justify-center ${joined ? 'invisible' : 'visible'}`}
+        className={`flex items-center justify-center ${joinedQuiz ? 'invisible' : 'visible'}`}
       >
         <BlueButton
           value="툴박스 얻기"
@@ -51,12 +54,5 @@ function Card2({ toolBoxCnt, auth, joined }) {
     </div>
   );
 }
-
-Card2.propTypes = {
-  // eslint 속이기 위한 data 타입
-  toolBoxCnt: PropTypes.number.isRequired,
-  auth: PropTypes.string.isRequired,
-  joined: PropTypes.bool.isRequired,
-};
 
 export default Card2;

--- a/src/pages/joinEvent/Card2.jsx
+++ b/src/pages/joinEvent/Card2.jsx
@@ -52,7 +52,7 @@ function Card2() {
         className={`flex items-center justify-center ${joinedQuiz ? 'invisible' : 'visible'}`}
       >
         <BlueButton
-          value="툴박스 얻기"
+          value="도구 얻기"
           onClickFunc={gotoMiniQuiz}
           styles="px-800 py-400 text-detail-2-medium"
         />

--- a/src/pages/joinEvent/Card2.jsx
+++ b/src/pages/joinEvent/Card2.jsx
@@ -1,19 +1,25 @@
-import React, { useContext } from 'react';
+import React, { useContext, useCallback } from 'react';
 import BlueButton from '@/components/buttons/BlueButton';
 import noToolBoxImage from '@/assets/images/noToolBoxImage.svg';
 import toolBoxImage from '@/assets/images/toolBoxImage.svg';
 import questionMark from '@/assets/images/questionMark.svg';
 import { AuthContext } from '@/context/authContext';
+import { useNavigate } from 'react-router-dom';
 
 function Card2() {
+  const navigate = useNavigate();
   const { userInfo } = useContext(AuthContext);
   const { toolBoxCnt, joinedQuiz } = userInfo;
   let imageSrc = noToolBoxImage;
   //QuizJoined 했으면 상품 받음
   //Card1에 있는 주석 참고!
-  if (joined) {
+  if (joinedQuiz) {
     imageSrc = toolBoxImage;
   }
+
+  const gotoMiniQuiz = useCallback(() => {
+    navigate('/event/miniquiz');
+  }, []);
 
   return (
     <div className="flex flex-col justify-between bg-card2 px-800 pt-700 pb-500 h-[417px] w-[320px] rounded-[30px]">
@@ -47,7 +53,7 @@ function Card2() {
       >
         <BlueButton
           value="툴박스 얻기"
-          onClickFunc={() => alert('툴박스 얻기')}
+          onClickFunc={gotoMiniQuiz}
           styles="px-800 py-400 text-detail-2-medium"
         />
       </div>

--- a/src/pages/joinEvent/JoinEventIntroMain.jsx
+++ b/src/pages/joinEvent/JoinEventIntroMain.jsx
@@ -4,7 +4,6 @@ import Card2 from '@/pages/joinEvent/Card2';
 import PhoneInputModal from '@/components/modal/PhoneInputModal';
 import { AuthContext } from '@/context/authContext';
 import BluePurpleButton from '@/components/buttons/BluePurpleButton';
-import GetItemModal from '@/components/modal/GetItemModal';
 
 function JoinEventIntroMain() {
   const { userInfo } = useContext(AuthContext);
@@ -12,8 +11,6 @@ function JoinEventIntroMain() {
 
   // 아래 변수들은 벡에서 가져올 내용
   const { haveCar, toolBoxCnt, phoneNumber } = userInfo;
-  //joinedQuiz는 userInfo에 추가
-  let joinedQuiz = false;
   let day = 2;
   const details = `캐스퍼 EV와 떠날 시간!\n깜빡하고 차키를 안 가져왔네요.. 어떻게 해야할까요?`;
   const disabled = !phoneNumber || !haveCar || toolBoxCnt === 0; // 결과 보기 버튼 클릭 가능 여부 변수명 변경 필요
@@ -32,13 +29,9 @@ function JoinEventIntroMain() {
         <div className="flex gap-2000 px-3000">
           <div className="space-y-1200">
             <div className="flex items-center gap-300">
-              <Card1 haveCar={haveCar} />
+              <Card1 />
               <div className="text-heading-1-bold text-neutral-white">+</div>
-              <Card2
-                toolBoxCnt={toolBoxCnt}
-                auth={phoneNumber}
-                joined={joinedQuiz}
-              />
+              <Card2 />
             </div>
             <div
               className={`text-center underline text-neutral-white text-shadow-default ${phoneNumber ? 'invisible' : 'visible'}`}

--- a/src/pages/joinEvent/MiniQuiz.jsx
+++ b/src/pages/joinEvent/MiniQuiz.jsx
@@ -14,7 +14,7 @@ function MiniQuiz() {
 
   return (
     <div className="flex px-3000 pb-2900">
-      <div className="relative w-[610px] h-[400px]">
+      <div className="relative min-w-[610px] h-[400px]">
         {countDownStart && (
           <div className="absolute inset-0 z-10 bg-black opacity-70 p-2000">
             <div className="text-center text-body-2-semibold text-primary-blue">

--- a/src/pages/joinEvent/WorldCup.jsx
+++ b/src/pages/joinEvent/WorldCup.jsx
@@ -9,7 +9,7 @@ function WorldCup() {
     <>
       <div className="px-3000 pt-2000 pb-2500">
         <div className="flex gap-2000">
-          <div className="w-[610px]">
+          <div className="min-w-[610px]">
             <div className="space-y-800">
               <div className="text-primary-blue text-detail-1-bold">
                 Event1. 자동차 얻기

--- a/src/pages/joinEvent/WorldCup.jsx
+++ b/src/pages/joinEvent/WorldCup.jsx
@@ -9,7 +9,7 @@ function WorldCup() {
     <>
       <div className="px-3000 pt-2000 pb-2500">
         <div className="flex gap-2000">
-          <div className="min-w-[610px]">
+          <div className="w-[610px]">
             <div className="space-y-800">
               <div className="text-primary-blue text-detail-1-bold">
                 Event1. 자동차 얻기

--- a/src/pages/miniquiz/ClickBox.jsx
+++ b/src/pages/miniquiz/ClickBox.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import '@/styles/global.css';
 
 function ClickBox({ text }) {
   return (
-    <div className="flex justify-center items-center bg-neutral-white min-w-[586px] min-h-[120px] rounded-[15px] border-op-30-blue border-2">
+    <div className="set-center bg-neutral-white min-w-[586px] min-h-[120px] rounded-[15px] border-op-30-blue border-2">
       {text}
     </div>
   );

--- a/src/pages/miniquiz/ClickBox.jsx
+++ b/src/pages/miniquiz/ClickBox.jsx
@@ -1,12 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import '@/styles/global.css';
 
 function ClickBox({ text }) {
+  const [isChosen, setIsChosen] = useState(false);
+
   return (
-    <div className="cursor-pointer hover:scale-105 transition-transform set-center text-body-3-semibold bg-neutral-white min-w-[586px] min-h-[120px] rounded-[15px] border-op-30-blue border-2">
+    <button className="hover:scale-105 transition-transform set-center text-body-3-semibold bg-neutral-white min-w-[586px] min-h-[120px] rounded-[15px] border-op-30-blue border-2">
       {text}
-    </div>
+    </button>
   );
 }
 

--- a/src/pages/miniquiz/ClickBox.jsx
+++ b/src/pages/miniquiz/ClickBox.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function ClickBox({ text }) {
+  return (
+    <div className="flex justify-center items-center bg-neutral-white min-w-[586px] min-h-[120px] rounded-[15px] border-op-30-blue border-2">
+      {text}
+    </div>
+  );
+}
+
+ClickBox.propTypes = {
+  text: PropTypes.string.isRequired,
+};
+
+export default ClickBox;

--- a/src/pages/miniquiz/ClickBox.jsx
+++ b/src/pages/miniquiz/ClickBox.jsx
@@ -4,7 +4,7 @@ import '@/styles/global.css';
 
 function ClickBox({ text }) {
   return (
-    <div className="set-center bg-neutral-white min-w-[586px] min-h-[120px] rounded-[15px] border-op-30-blue border-2">
+    <div className="cursor-pointer hover:scale-105 transition-transform set-center text-body-3-semibold bg-neutral-white min-w-[586px] min-h-[120px] rounded-[15px] border-op-30-blue border-2">
       {text}
     </div>
   );

--- a/src/pages/miniquiz/MiniQuiz.jsx
+++ b/src/pages/miniquiz/MiniQuiz.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+function MiniQuiz() {
+  return (
+    <div className="bg-miniquiz-paper fixed inset-0 flex items-center justify-center z-[10]">
+      <div className="flex px-5000 py-500 gap-400">
+        <div className="text-detail-1-bold h-800 w-[220px]">
+          CASPER ELECTRIC
+        </div>
+        <div className="text-detail-1-bold h-800 text-nowrap">
+          Event 2. 도구 얻기
+        </div>
+        <div className="text-detail-1-bold h-800 w-[220px]">
+          CASPER ELECTRIC
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MiniQuiz;

--- a/src/pages/miniquiz/MiniQuiz.jsx
+++ b/src/pages/miniquiz/MiniQuiz.jsx
@@ -1,20 +1,33 @@
 import React from 'react';
+import '@/styles/global.css';
 
 function MiniQuiz() {
+  //TODO 백에서 데이터 가져오기
+
+  const question =
+    '캐스퍼 EV는 000 을(를) 통해 주변 보행자에게 차량의 존재를 알려줄 수 있어요!';
   return (
-    <div className="bg-miniquiz-paper fixed inset-0 flex items-center justify-center z-[10]">
-      <div className="flex px-5000 py-500 gap-400">
-        <div className="text-detail-1-bold h-800 w-[220px]">
-          CASPER ELECTRIC
+    <>
+      <div className="bg-miniquiz-paper fixed inset-0 z-[10]">
+        <div className="flex px-5000 py-500 gap-400 mb-2500">
+          <div className="flex items-end text-detail-1-bold h-800 w-[280px] text-nowrap">
+            CASPER ELECTRIC
+          </div>
+          <div className="flex items-end text-detail-2-regular h-800 text-primary-blue text-nowrap">
+            Event 2. 도구 얻기
+          </div>
+          <div className="flex items-end text-detail-2-regular h-800 text-nowrap">
+            월드컵 일일 미니퀴즈
+          </div>
         </div>
-        <div className="text-detail-1-bold h-800 text-nowrap">
-          Event 2. 도구 얻기
-        </div>
-        <div className="text-detail-1-bold h-800 w-[220px]">
-          CASPER ELECTRIC
+        <div className="flex flex-col items-center px-5000 mb-2000">
+          <div className="rounded-[8px] skyblue-box text-detail-1-bold mb-500">
+            월드컵 일일 미니퀴즈
+          </div>
+          <div className="text-center text-body-1-bold">{question}</div>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/src/pages/miniquiz/MiniQuiz.jsx
+++ b/src/pages/miniquiz/MiniQuiz.jsx
@@ -22,7 +22,7 @@ function MiniQuiz() {
             월드컵 일일 미니퀴즈
           </div>
         </div>
-        <div className="flex flex-col items-center px-5000 mb-2000">
+        <div className="flex flex-col items-center mb-2000">
           <div className="rounded-[8px] skyblue-box text-detail-1-bold mb-500">
             월드컵 일일 미니퀴즈
           </div>

--- a/src/pages/miniquiz/MiniQuiz.jsx
+++ b/src/pages/miniquiz/MiniQuiz.jsx
@@ -1,22 +1,24 @@
 import React from 'react';
 import '@/styles/global.css';
+import ClickBox from './ClickBox';
 
 function MiniQuiz() {
   //TODO 백에서 데이터 가져오기
+  // try catch를 이용하여 12 ~ 13시는 다른 화면 return
 
   const question =
     '캐스퍼 EV는 000 을(를) 통해 주변 보행자에게 차량의 존재를 알려줄 수 있어요!';
   return (
     <>
-      <div className="bg-miniquiz-paper fixed inset-0 z-[10]">
+      <div className="bg-miniquiz-paper fixed inset-0 z-[10] text-nowrap">
         <div className="flex px-5000 py-500 gap-400 mb-2500">
-          <div className="flex items-end text-detail-1-bold h-800 w-[280px] text-nowrap">
+          <div className="flex items-end text-detail-1-bold h-800 min-w-[280px]">
             CASPER ELECTRIC
           </div>
-          <div className="flex items-end text-detail-2-regular h-800 text-primary-blue text-nowrap">
+          <div className="flex items-end text-detail-2-regular h-800 text-primary-blue">
             Event 2. 도구 얻기
           </div>
-          <div className="flex items-end text-detail-2-regular h-800 text-nowrap">
+          <div className="flex items-end text-detail-2-regular h-800">
             월드컵 일일 미니퀴즈
           </div>
         </div>
@@ -24,7 +26,13 @@ function MiniQuiz() {
           <div className="rounded-[8px] skyblue-box text-detail-1-bold mb-500">
             월드컵 일일 미니퀴즈
           </div>
-          <div className="text-center text-body-1-bold">{question}</div>
+          <div className="text-center text-body-1-bold mb-2000">{question}</div>
+          <div className="grid grid-cols-2 gap-x-600 gap-y-600">
+            <ClickBox text="hello" />
+            <ClickBox text="hello" />
+            <ClickBox text="hello" />
+            <ClickBox text="hello" />
+          </div>
         </div>
       </div>
     </>

--- a/src/pages/newCarIntro/NewCarDetail.jsx
+++ b/src/pages/newCarIntro/NewCarDetail.jsx
@@ -22,8 +22,8 @@ function NewCarDetail() {
         </div>
       </div>
       <div className="grid grid-cols-2 mx-5000 gap-x-600 gap-y-2900">
-        {newCarDetailData.map((item, idx) => (
-          <NewCarDetailBox details={item} key={idx} />
+        {newCarDetailData.map(item => (
+          <NewCarDetailBox details={item} key={item.id} />
         ))}
       </div>
     </>

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -4,6 +4,7 @@ import App from '@/App';
 import EventIntro from '@/pages/eventIntro/EventIntro';
 import JoinEventIntro from '@/pages//joinEvent/JoinEventIntro';
 import NewCarIntro from '@/pages/newCarIntro/NewCarIntro';
+import MiniQuiz from '@/pages/miniquiz/MiniQuiz';
 
 const router = createBrowserRouter([
   {
@@ -24,7 +25,7 @@ const router = createBrowserRouter([
           },
           {
             path: 'miniquiz',
-            element: <></>,
+            element: <MiniQuiz />,
           },
         ],
       },

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,3 +5,7 @@
 .skyblue-box {
   @apply bg-background-lightblue px-400 py-100 text-primary-blue;
 }
+
+.set-center {
+  @apply flex items-center justify-center;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,6 +29,7 @@
           //그림 배경 정의
           'new-car-intro': "url('@/assets/images/newCarIntroBg.svg')",
           'join-event-main': "url('@/assets/images/joinEventMainBg.svg')",
+          'miniquiz-paper': "url('@/assets/images/miniQuizBg.svg')",
           // 그라데이션 색상 정의
           'gradient-blue-purple':
             'linear-gradient(90deg, #0128FF 0%, #AD00FF 100%)',


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- Feat/#53/mini quiz

### 💡 작업동기
- 일일 퀴즈 이벤트 진행을 위한 컴포넌트입니다.

### 🔑 주요 변경사항
- flex justify-center items-center를 자주 사용하는 거 같아 apply 적용했습니다.(제가 한 파일들만 변경했어요!)
- 승섭님 의견대로 Card1, Card2를 props를 받지 않고 context를 사용했습니다. 데이터 전달의 복잡성을 낮추는 게 좋을 거 같았습니다.
- 버튼에 라우팅 시켰습니다.
- miniquiz 레이아웃 작성했습니다.

### 🏞 스크린샷

https://github.com/user-attachments/assets/1ba30ba2-edf9-4f86-a5db-0717e9579f74



### 관련 이슈
- 패딩으로 인해 browser를 조금만 줄여도 버튼이 겹치는 문제가 발생하여 패딩을 제거했습니다.