### PR TITLE
[feat] worldCup select animation effect

### DIFF
--- a/src/pages/worldCup/WorldCupGame.jsx
+++ b/src/pages/worldCup/WorldCupGame.jsx
@@ -6,50 +6,105 @@ import PropTypes from 'prop-types';
 
 function WorldCupGame({ title = '8강', onselect }) {
   const [currentState, setCurrentState] = useState(0);
+  const [animationClass, setAnimationClass] = useState('');
 
-  const getText1Style = () => {
+  const getTextLeftStyle = () => {
     return currentState === 1
       ? 'text-gradient-blue-purple'
       : 'text-neutral-black';
   };
 
-  const getImage1Src = () => {
+  const getLeftImageSrc = () => {
     return currentState === 2 ? data[0].grayImage : data[0].image;
   };
 
-  const getText2Style = () => {
+  const getTextRightStyle = () => {
     return currentState === 2
       ? 'text-gradient-blue-purple'
       : 'text-neutral-black';
   };
 
-  const getImage2Src = () => {
+  const getRightImageSrc = () => {
     return currentState === 1 ? data[1].grayImage : data[1].image;
   };
 
+  const handleCurrentState = isLeft => {
+    if (animationClass) return;
+    if (isLeft) {
+      setCurrentState(1);
+    } else {
+      setCurrentState(2);
+    }
+  };
+
+  const handleMouseLeave = () => {
+    setCurrentState(0);
+  };
+
+  const handleAnimation = isLeft => {
+    setCurrentState(0);
+    if (isLeft) {
+      setAnimationClass('animate-slide-left-to-right');
+    } else {
+      setAnimationClass('animate-slide-right-to-left');
+    }
+    // 1초 후 애니메이션 클래스 제거
+    // setTimeout(() => {
+    //   setAnimationClass('');
+    // }, 1000);
+  };
+
   return (
-    <div className="fixed inset-0 w-full z-100 min-w-[1104px] min-h-[860px]">
+    <div className="fixed inset-0 w-full z-[10] min-w-[1104px] min-h-[860px]">
       <div className="relative">
         <WorldCupHeader />
         <WorldCupTitle title={title} />
+        {animationClass === '' ? (
+          <span className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-primary-blue text-detail-1-bold">
+            VS
+          </span>
+        ) : null}
         <div className="flex h-screen">
-          <div className="flex flex-col items-center justify-center w-1/2 bg-gradient-cobaltblue-white pl-2500 pt-2000">
-            <img
-              src={getImage1Src()}
-              alt={data[0].story}
-              className={`${currentState === 1 ? 'border-solid border-[8px] border-gradient-blue-purple' : null}`}
-            />
-            <p className={`text-detail-2-semibold ${getText1Style()}`}>
+          <div
+            className={`flex flex-col items-center justify-center pt-[5%] ${currentState === 2 ? 'bg-neutral-100' : 'bg-gradient-cobaltblue-white-opposite'} ${animationClass === 'animate-slide-left-to-right' ? 'animate-slide-left-to-right' : animationClass === 'animate-slide-right-to-left' ? 'animate-remove-left-to-right w-[0%]' : 'w-1/2'}`}
+          >
+            <div
+              className={`w-[455px] h-[435px] rounded-[35px] z-[50] flex items-start pt-2 mb-1000 justify-center ${currentState === 1 ? 'bg-gradient-blue-purple' : 'bg-transparent'}`}
+            >
+              <img
+                src={getLeftImageSrc()}
+                alt={data[0].story}
+                onMouseEnter={() => handleCurrentState(true)}
+                onMouseLeave={handleMouseLeave}
+                onClick={() => handleAnimation(true)}
+                className={`z-[100] w-[440px] h-[490px] ${animationClass === 'animate-slide-right-to-left' ? 'hidden' : null}`}
+              />
+            </div>
+
+            <p
+              className={`text-detail-2-semibold ${getTextLeftStyle()} ${animationClass === 'animate-slide-right-to-left' ? 'hidden' : null}`}
+            >
               {data[0].story}
             </p>
           </div>
-          <div className="flex flex-col items-center justify-center w-1/2 bg-gradient-lightblue-white pr-2500 pt-2000">
-            <img
-              src={getImage2Src()}
-              alt={data[1].story}
-              className={`${currentState === 2 ? 'border-solid border-[8px] border-gradient-blue-purple' : ''}`}
-            />
-            <p className={`text-detail-2-semibold ${getText2Style()}`}>
+          <div
+            className={`flex flex-col items-center justify-center pt-[5%] ${currentState === 1 ? 'bg-neutral-100' : 'bg-gradient-lightblue-white'} ${animationClass === 'animate-slide-right-to-left' ? 'animate-slide-right-to-left' : animationClass === 'animate-slide-left-to-right' ? 'animate-remove-right-to-left w-[0%]' : 'w-1/2'}`}
+          >
+            <div
+              className={`w-[455px] h-[435px] rounded-[35px] z-[50] flex items-start pt-2 mb-1000 justify-center ${currentState === 2 ? 'bg-gradient-blue-purple' : 'bg-transparent'}`}
+            >
+              <img
+                src={getRightImageSrc()}
+                alt={data[1].story}
+                onMouseEnter={() => handleCurrentState(false)}
+                onMouseLeave={handleMouseLeave}
+                onClick={() => handleAnimation(false)}
+                className={`z-[100] w-[440px] h-[490px] ${animationClass === 'animate-slide-left-to-right' ? 'hidden' : null}`}
+              />
+            </div>
+            <p
+              className={`text-detail-2-semibold ${getTextRightStyle()} ${animationClass === 'animate-slide-left-to-right' ? 'hidden' : null}`}
+            >
               {data[1].story}
             </p>
           </div>

--- a/src/pages/worldCup/WorldCupHeader.jsx
+++ b/src/pages/worldCup/WorldCupHeader.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 function WorldCupHeader() {
   return (
-    <div className="absolute flex w-full h-[32px] items-center top-[5%] left-[5%]">
+    <div className="absolute flex w-full h-[32px] items-center top-[2%] left-[5%]">
       <span className="text-detail-1-bold text-neutral-black mr-2000">
         CASPER ELECTRIC
       </span>

--- a/src/pages/worldCup/WorldCupTitle.jsx
+++ b/src/pages/worldCup/WorldCupTitle.jsx
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 
 function WorldCupTitle({ title }) {
   return (
-    <div className="absolute flex flex-col items-center top-[10%] w-full">
+    <div className="absolute flex flex-col items-center top-[7%] w-full">
       <div className="w-[160px] h-[45px] bg-neutral-white flex justify-center items-center text-primary-blue text-detail-1-bold rounded-xl mb-4">
         {title}
       </div>
-      <div className="text-body-1-bold text-neutral-black">
+      <div className="text-body-1-bold text-gray-900">
         둘 중 제일 피하고 싶은 상황은?
       </div>
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,6 +39,8 @@
             'linear-gradient(90deg, #8285F6 0%, #C5F0FF 100%)',
           'gradient-lightblue-white':
             'linear-gradient(90deg, #E0EAFF 0%, #FFF 100%)',
+          'gradient-cobaltblue-white-opposite':
+            'linear-gradient(270deg, #C5F0FF 0%, #FFF 100%)',
           'gradient-lightblue-white-vertical':
             'linear-gradient(180deg, #E0EAFF 0%, #FFF 100%)',
           card1: 'linear-gradient(180deg, #C5F0FF 0%, #FFF 99.95%)',
@@ -382,10 +384,30 @@
             '0%': { transform: 'translateY(0)' },
             '100%': { transform: 'translateY(-100vh)' },
           },
+          expandLeftToRight: {
+            '0%': { width: '50%' },
+            '100%': { width: '100%' },
+          },
+          expandRightToLeft: {
+            '0%': { width: '50%' },
+            '100%': { width: '100%' },
+          },
+          contractionLeftToRight: {
+            '0%': { width: '50%' },
+            '100%': { width: '0%' },
+          },
+          contractionRightToLeft: {
+            '0%': { width: '50%' },
+            '100%': { width: '0%' },
+          },
         },
         animation: {
           'slide-down': 'slide-down 0.5s ease-out forwards',
           'slide-up': 'slide-up 0.5s ease-in forwards',
+          'slide-left-to-right': 'expandLeftToRight 1s forwards',
+          'slide-right-to-left': 'expandRightToLeft 1s forwards',
+          'remove-left-to-right': 'contractionLeftToRight 1s forwards',
+          'remove-right-to-left': 'contractionRightToLeft 1s forwards',
         },
       },
     },


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feature/#56/worldCupDetail

### 💡 작업동기
- 월드컵게임 진행시 아이템을 클릭하면 해당 아이템이 중앙으로 이동하는 애니메이션 추가 

### 🔑 주요 변경사항
- 월드컵게임 진행시 아이템을 클릭하면 해당 아이템이 중앙으로 이동하는 애니메이션 추가 

### 🏞 스크린샷

https://github.com/user-attachments/assets/d0de1a11-6575-4370-a50a-a488189849a1


### 관련 이슈
- 없음
