### PR TITLE
Feat/#89/eventAdminHeader

### DIFF
--- a/service/src/components/header/AdminHeader.jsx
+++ b/service/src/components/header/AdminHeader.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+function AdminHeader() {
+  return (
+    <div className="pt-1000 flex justify-between w-[90%]">
+      <div className="set-center gap-500">
+        <span className="text-heading-2-bold text-neutral-black">
+          이벤트 관리
+        </span>
+        <div className="bg-[#AEAEAE] px-4 py-1 rounded-full text-white set-center text-detail-1-semibold">
+          진행중
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AdminHeader;

--- a/service/src/components/modal/PhoneAuthModal.jsx
+++ b/service/src/components/modal/PhoneAuthModal.jsx
@@ -14,6 +14,7 @@ function PhoneAuthModal({
   const [validateCode, setValidateCode] = useState('');
   const [isValid, setIsValid] = useState(false);
   const [firstClick, setFirstClick] = useState(false);
+  const [alertText, setAlertText] = useState('인증번호 형식이 맞지 않습니다!');
   const handleInputText = e => {
     setValidateCode(e.target.value);
     setIsValid(e.target.value.length === 6);
@@ -39,7 +40,8 @@ function PhoneAuthModal({
         console.error('API 통신 실패:', error);
       }
     } else {
-      alert('ddd');
+      setAlertText('인증번호를 다시 확인해주세요!');
+      setIsValid(false);
     }
   };
   const firstClickEvent = () => {
@@ -57,7 +59,7 @@ function PhoneAuthModal({
         ></input>
         {!isValid && firstClick && (
           <span className="absolute top-[60%] left-[2%] text-red-500 text-detail-3-regular">
-            인증번호 형식이 맞지 않습니다!
+            {alertText}
           </span>
         )}
       </div>

--- a/service/src/pages/admin/AdminEditEvent.jsx
+++ b/service/src/pages/admin/AdminEditEvent.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function AdminEditEvent() {
+  return <div>ddd</div>;
+}
+
+export default AdminEditEvent;

--- a/service/src/pages/admin/AdminIndex.jsx
+++ b/service/src/pages/admin/AdminIndex.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import AdminHeader from '@/components/header/AdminHeader';
+
+function AdminIndex() {
+  return (
+    <div className="bg-[#DADADA] flex flex-col items-center">
+      <AdminHeader />
+      <Outlet />
+    </div>
+  );
+}
+
+export default AdminIndex;

--- a/service/src/pages/eventIntro/EventIntroMain.jsx
+++ b/service/src/pages/eventIntro/EventIntroMain.jsx
@@ -34,12 +34,12 @@ function EventIntroMain() {
         </p>
         <div className="flex mt-600 gap-300">
           <Link to="event">
-            <button className="flex items-center justify-center transition-transform rounded-full px-800 py-400 bg-neutral-white text-neutral-black text-detail-3-semibold hover:scale-105">
+            <button className="flex items-center justify-center rounded-full px-1000 py-500 bg-neutral-white text-neutral-black text-detail-3-semibold hover:scale-105 duration-200">
               이벤트 참여하기
             </button>
           </Link>
           <Link to="introduce">
-            <button className="flex items-center justify-center bg-transparent rounded-full px-800 py-400 text-neutral-black text-detail-3-semibold border-[2px] border-solid border-neutral-black hover:scale-105 transition-transform">
+            <button className="flex items-center justify-center bg-transparent rounded-full px-800 py-400 text-neutral-black text-detail-3-semibold border-[2px] border-solid border-neutral-black hover:scale-105 duration-200">
               캐스퍼 EV 알아보기
               <img src={arrow} alt="move" />
             </button>

--- a/service/src/pages/joinEvent/commentList/RefreshData.jsx
+++ b/service/src/pages/joinEvent/commentList/RefreshData.jsx
@@ -1,17 +1,32 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ReloadComment from '@/assets/icons/reloadComment.svg';
 import PropTypes from 'prop-types';
-import getNowTime from '@/utils/getNowTime';
 
-function RefreshData({ nowTime, setNowTime, onClickrefreshData }) {
+function RefreshData({ nowTime, onClickrefreshData }) {
+  const [isRotating, setIsRotating] = useState(false);
+  const [isDisabled, setIsDisabled] = useState(false);
+
+  const handleRefresh = () => {
+    if (isDisabled) return;
+
+    setIsRotating(true);
+    setIsDisabled(true);
+    onClickrefreshData();
+
+    setTimeout(() => {
+      setIsRotating(false);
+      setIsDisabled(false);
+    }, 1000);
+  };
+
   return (
     <div className="flex items-center mr-600 gap-400">
       <span className="text-detail-3-regular text-neutral-500">{nowTime}</span>
       <img
         src={ReloadComment}
         alt="ReloadComment"
-        onClick={onClickrefreshData}
-        className="cursor-pointer"
+        onClick={handleRefresh}
+        className={`cursor-pointer ${isRotating ? 'rotate-180' : ''} `}
       />
     </div>
   );
@@ -19,7 +34,6 @@ function RefreshData({ nowTime, setNowTime, onClickrefreshData }) {
 
 RefreshData.propTypes = {
   nowTime: PropTypes.string.isRequired,
-  setNowTime: PropTypes.func.isRequired,
   onClickrefreshData: PropTypes.func.isRequired,
 };
 

--- a/service/src/router.jsx
+++ b/service/src/router.jsx
@@ -10,6 +10,8 @@ import WorldCupResult from '@/pages/worldCup/WorldCupResult';
 import MiniQuizResult from '@/pages/miniquiz/MiniQuizResult';
 import NoQuiz from '@/pages/miniquiz/NoQuiz';
 import Reward from '@/pages/joinEvent/Reward';
+import AdminIndex from '@/pages/admin/AdminIndex';
+import AdminEditEvent from '@/pages/admin/AdminEditEvent';
 
 const router = createBrowserRouter([
   {
@@ -55,6 +57,11 @@ const router = createBrowserRouter([
         element: <NewCarIntro />,
       },
     ],
+  },
+  {
+    path: '/admin',
+    element: <AdminIndex />,
+    children: [{ index: true, element: <AdminEditEvent /> }],
   },
 ]);
 

--- a/service/src/styles/global.css
+++ b/service/src/styles/global.css
@@ -22,3 +22,8 @@
   background-origin: border-box;
   background-clip: content-box, border-box;
 }
+
+.rotate-180 {
+  transition: transform 1s;
+  transform: rotate(180deg);
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- Feat/#89/eventAdminHeader

### 💡 작업동기
- 캐스퍼 이벤트 페이지에 대한 admin 페이지 

### 🔑 주요 변경사항
1. eventAdminHeader 컴포넌트 추가
2. admin 페이지 라우터 추가 및 구조 잡기
3. 인증번호 확인하는 모달에서 인증번호 틀렸을때 로직 수정
4. 댓글에서 refresh 버튼 클릭시 180도 돌아가는 애니메이션 추가

### 🏞 스크린샷
<img width="1440" alt="스크린샷 2024-08-14 오전 12 32 12" src="https://github.com/user-attachments/assets/382a1f2a-6758-41e1-be90-4351c0ba1f9f">

### 관련 이슈
- Admin 페이지 Tab 어떤 방식으로 할지 의논해야함
