### PR TITLE
Feat/#111/AdminDrawApi 연동 및 useBlocker 추가

### DIFF
--- a/admin/src/api/draw/index.js
+++ b/admin/src/api/draw/index.js
@@ -1,0 +1,7 @@
+import { post, get, patch, put, del } from '@/api/index';
+
+const getAdminDraw = day => get(`/admin/draw/daily-info/${day}`);
+
+const putAdminDraw = body => put(`/admin/draw/daily-info`, body);
+
+export { getAdminDraw, putAdminDraw };

--- a/admin/src/api/index.js
+++ b/admin/src/api/index.js
@@ -1,11 +1,9 @@
 const ApiRequest = async (url, method, body) => {
   const accessToken = sessionStorage.getItem('userInfo');
-
   try {
     const options = {
       method,
       headers: {
-        'Content-Type': 'application/json',
         ...(accessToken && {
           Authorization: `Bearer ${accessToken}`,
         }),
@@ -14,7 +12,12 @@ const ApiRequest = async (url, method, body) => {
     };
 
     if (body) {
-      options.body = JSON.stringify(body);
+      if (!(body instanceof FormData)) {
+        options.headers['Content-Type'] = 'application/json';
+        options.body = JSON.stringify(body);
+      } else {
+        options.body = body;
+      }
     }
 
     const response = await fetch(

--- a/admin/src/api/miniQuizAnswer/index.js
+++ b/admin/src/api/miniQuizAnswer/index.js
@@ -3,9 +3,6 @@ import { post, get, patch, put, del } from '@/api/index';
 const getAdminMiniQuizAnswer = day => get(`/admin/quiz/answers/${day}`);
 
 const putAdminMiniQuizAnswer = (day, body) =>
-  put(`/admin/quiz/answers/${day}`, {
-    answerNum: body.answerNum,
-    quizImage: body.quizImage,
-  });
+  put(`/admin/quiz/answers/${day}`, body);
 
 export { getAdminMiniQuizAnswer, putAdminMiniQuizAnswer };

--- a/admin/src/components/form/ImageUploader.jsx
+++ b/admin/src/components/form/ImageUploader.jsx
@@ -1,9 +1,15 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import ImageAddIcon from '@/assets/icons/imageAddIcon.svg';
 
 function ImageUploader({ onChange, imageUrl, label }) {
   const [imagePreview, setImagePreview] = useState(imageUrl || '');
+
+  useEffect(() => {
+    if (typeof imageUrl === 'string') {
+      setImagePreview(imageUrl);
+    }
+  }, [imageUrl]);
 
   const handleImageChange = e => {
     const file = e.target.files[0];
@@ -13,7 +19,7 @@ function ImageUploader({ onChange, imageUrl, label }) {
     const reader = new FileReader();
     reader.onloadend = () => {
       setImagePreview(reader.result);
-      onChange(file);
+      onChange(file); // 파일 객체를 onChange로 전달
     };
     reader.readAsDataURL(file);
   };
@@ -57,7 +63,7 @@ function ImageUploader({ onChange, imageUrl, label }) {
 
 ImageUploader.propTypes = {
   onChange: PropTypes.func.isRequired,
-  imageUrl: PropTypes.string,
+  imageUrl: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   label: PropTypes.string.isRequired,
 };
 

--- a/admin/src/components/header/AdminHeader.jsx
+++ b/admin/src/components/header/AdminHeader.jsx
@@ -19,7 +19,6 @@ function AdminHeader() {
       const previousDay = new Date(dateInfo);
       previousDay.setDate(previousDay.getDate() - 1);
       setDateInfo(dateFormatting(previousDay));
-      console.log(previousDay);
     }
   };
 
@@ -28,7 +27,6 @@ function AdminHeader() {
       const nextDay = new Date(dateInfo);
       nextDay.setDate(nextDay.getDate() + 1);
       setDateInfo(dateFormatting(nextDay));
-      console.log(nextDay);
     }
   };
   return (

--- a/admin/src/components/modal/ModalFrame.jsx
+++ b/admin/src/components/modal/ModalFrame.jsx
@@ -13,7 +13,9 @@ function ModalFrame({ text, onClickNo, onClickYes }) {
     <ModalPortal>
       <div className="fixed inset-0 set-center bg-opacity-50 bg-neutral-black z-[10]">
         <div className="bg-neutral-white px-1000 pt-2000 pb-1000 flex flex-col items-center rounded-[20px]">
-          <p className="text-body-3-bold text-neutral-black mb-900">{text}</p>
+          <p className="text-body-3-bold text-neutral-black mb-900 w-[590px] text-center">
+            {text}
+          </p>
           <div className="set-center gap-500">
             <button
               onClick={onClickNo}

--- a/admin/src/hooks/useFormData.js
+++ b/admin/src/hooks/useFormData.js
@@ -1,0 +1,20 @@
+import { useCallback } from 'react';
+
+const useFormData = () => {
+  const createFormData = useCallback(data => {
+    const formData = new FormData();
+
+    Object.keys(data).forEach(key => {
+      if (data[key] !== undefined && data[key] !== null) {
+        console.log(data[key]);
+        formData.append(key, data[key]);
+      }
+    });
+
+    return formData;
+  }, []);
+
+  return createFormData;
+};
+
+export default useFormData;

--- a/admin/src/pages/draw/Draw.jsx
+++ b/admin/src/pages/draw/Draw.jsx
@@ -1,47 +1,88 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import AdminEditHeader from '@/components/header/AdminEditHeader';
 import AdminEditDrawContent from './DrawContent';
 import BlackButton from '@/components/buttons/BlackButton';
+import { getAdminDraw, putAdminDraw } from '@/api/draw/index';
+import { DateContext } from '@/context/dateContext';
+import useFetch from '@/hooks/useFetch';
+import ModalFrame from '@/components/modal/ModalFrame';
+import useFormData from '@/hooks/useFormData';
 
 function Draw() {
-  const [drawData, setDrawData] = useState({
-    id: 1,
-    draw_date: '2024-08-12',
-    lose_image:
-      'https://softeer4-team8.s3.ap-northeast-2.amazonaws.com/%E1%84%8C%E1%85%A1%E1%84%8C%E1%85%A5%E1%86%AB%E1%84%80%E1%85%A5.svg',
-    lose_message: 'Sorry, you lose! Try again',
-    lose_scenario: 'The opposing team outplayed you!',
-    win_image:
-      'https://softeer4-team8.s3.ap-northeast-2.amazonaws.com/%E1%84%8C%E1%85%A1%E1%84%8C%E1%85%A5%E1%86%AB%E1%84%80%E1%85%A5.svg',
-    win_message: 'Congraulation!, You have won!',
-    daily_message:
-      '캐스퍼 EV와 떠날 시간!\n 깜빡하고 차키를 안 가져왔네요.. 어떻게 해야할까요?',
-  });
+  const { dateInfo } = useContext(DateContext);
+  const {
+    data: initialData,
+    loading,
+    error,
+    refetch,
+  } = useFetch(getAdminDraw, dateInfo);
+  const [drawData, setDrawData] = useState(null);
+  const [openModal, setOpenModal] = useState(false);
+  const createFormData = useFormData();
 
-  const handleChange = (field, value) => {
+  useEffect(() => {
+    if (initialData) {
+      if (initialData.code === 'NO_DAILY_INFO') {
+        setDrawData({
+          drawDate: '',
+          loseImage: '',
+          loseMessage: '',
+          loseScenario: '',
+          winImage: '',
+          winMessage: '',
+          commonScenario: '',
+        });
+      } else {
+        setDrawData(initialData);
+      }
+    }
+  }, [initialData]);
+
+  const handleChange = (key, value) => {
     setDrawData(prevState => ({
       ...prevState,
-      [field]: value,
+      [key]: value,
     }));
   };
 
   const handleSubmit = async () => {
-    // try {
-    //   const response = await axios.put(`/api/quiz/${drawData.id}`, drawData);
-    //   console.log('수정된 데이터가 서버에 저장되었습니다.', response.data);
-    // } catch (error) {
-    //   console.error('수정 요청 중 오류가 발생했습니다.', error);
-    // }
-    console.log('ddddd');
+    const formData = createFormData(drawData);
+    const response = await putAdminDraw(formData);
+    console.log(response);
+    if (response.status === 200) {
+      await refetch();
+    } else {
+      alert('수정이 불가능합니다!');
+    }
+    setOpenModal(false);
   };
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  if (!drawData) {
+    return <div>No draw data available</div>;
+  }
 
   return (
     <div className="w-[100%] mt-1000">
       <AdminEditHeader info="응모 결과 수정" />
       <div className="flex-col w-[100%] set-center bg-neutral-white rounded-b-[10px] py-1000">
         <AdminEditDrawContent response={drawData} onChange={handleChange} />
-        <BlackButton value="수정하기" onClickFunc={handleSubmit} />
+        <BlackButton value="수정하기" onClickFunc={() => setOpenModal(true)} />
       </div>
+      {openModal && (
+        <ModalFrame
+          text="정말 응모 결과를 수정하실 건가요?"
+          onClickNo={() => setOpenModal(false)}
+          onClickYes={handleSubmit}
+        />
+      )}
     </div>
   );
 }

--- a/admin/src/pages/draw/DrawContent.jsx
+++ b/admin/src/pages/draw/DrawContent.jsx
@@ -8,41 +8,41 @@ function DrawContent({ response, onChange }) {
     <>
       <InputForm
         label="일일 메세지"
-        id="dailyMessage"
-        placeholder={response.daily_message}
-        value={response.daily_message}
-        onChange={value => onChange('daily_message', value)}
+        id="commonScenario"
+        placeholder={response.commonScenario}
+        value={response.commonScenario}
+        onChange={value => onChange('commonScenario', value)}
       />
       <InputForm
         label="실패 메세지"
         id="loseMessage"
-        placeholder={response.lose_message}
-        value={response.lose_message}
-        onChange={value => onChange('lose_message', value)}
+        placeholder={response.loseMessage}
+        value={response.loseMessage}
+        onChange={value => onChange('loseMessage', value)}
       />
       <InputForm
         label="실패 시나리오"
         id="loseScenario"
-        placeholder={response.lose_scenario}
-        value={response.lose_scenario}
-        onChange={value => onChange('lose_scenario', value)}
+        placeholder={response.loseScenario}
+        value={response.loseScenario}
+        onChange={value => onChange('loseScenario', value)}
       />
       <ImageUploader
         label="실패 이미지"
-        imageUrl={response.lose_image}
-        onChange={file => onChange('lose_image', file)}
+        imageUrl={response.loseImage}
+        onChange={file => onChange('loseImage', file)}
       />
       <InputForm
         label="성공 메세지"
         id="winMessage"
-        placeholder={response.win_message}
-        value={response.win_message}
-        onChange={value => onChange('win_message', value)}
+        placeholder={response.winMessage}
+        value={response.winMessage}
+        onChange={value => onChange('winMessage', value)}
       />
       <ImageUploader
         label="성공 이미지"
-        imageUrl={response.win_image}
-        onChange={file => onChange('win_image', file)}
+        imageUrl={response.winImage}
+        onChange={file => onChange('winImage', file)}
       />
     </>
   );

--- a/admin/src/pages/miniQuizAnswer/MiniQuizAnswer.jsx
+++ b/admin/src/pages/miniQuizAnswer/MiniQuizAnswer.jsx
@@ -9,6 +9,7 @@ import {
 import { DateContext } from '@/context/dateContext';
 import useFetch from '@/hooks/useFetch';
 import ModalFrame from '@/components/modal/ModalFrame';
+import useFormData from '@/hooks/useFormData';
 
 function MiniQuizAnswer() {
   const { dateInfo } = useContext(DateContext);
@@ -20,6 +21,7 @@ function MiniQuizAnswer() {
   } = useFetch(getAdminMiniQuizAnswer, dateInfo);
   const [quizAnswerData, setQuizAnswerData] = useState(null);
   const [openModal, setOpenModal] = useState(false);
+  const createFormData = useFormData();
 
   useEffect(() => {
     if (initialData) {
@@ -27,16 +29,10 @@ function MiniQuizAnswer() {
     }
   }, [initialData]);
 
-  const handleSubmit = async () => {
-    // quizAnswerData.quizImage 를 현재는 File형식으로 json 으로 보내는데 이 부분에서 formData 형식으로 바꿔서 보내야함..
-    // const formData = new FormData();
-    // formData.append('answerNum', quizAnswerData.answerNum);
+  const HandleSubmit = async () => {
+    const formData = createFormData(quizAnswerData);
 
-    // if (quizAnswerData.quizImage) {
-    //   formData.append('quizImage', quizAnswerData.quizImage);
-    // }
-
-    const response = await putAdminMiniQuizAnswer(dateInfo, quizAnswerData);
+    const response = await putAdminMiniQuizAnswer(dateInfo, formData);
     if (response.status === 200) {
       await refetch();
     } else {
@@ -78,7 +74,7 @@ function MiniQuizAnswer() {
         <ModalFrame
           text="정말 미니퀴즈 답변을 수정하실 건가요?"
           onClickNo={() => setOpenModal(false)}
-          onClickYes={handleSubmit}
+          onClickYes={HandleSubmit}
         />
       )}
     </div>

--- a/admin/src/pages/miniQuizAnswer/MiniQuizAnswerContent.jsx
+++ b/admin/src/pages/miniQuizAnswer/MiniQuizAnswerContent.jsx
@@ -15,7 +15,7 @@ function MiniQuizAnswerContent({ response, onChange }) {
       />
       <ImageUploader
         label="정답 이미지"
-        imagePreview={response.quizImage}
+        imageUrl={response.quizImage}
         onChange={file => onChange('quizImage', file)}
       />
     </>


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- Feat/#111/AdminDrawApi

### 💡 작업동기
- AdminDrawApi 연동

### 🔑 주요 변경사항
1. 공통으로 사용하는 api 로직에 분기 처리해 formData 처리하는 로직 추가
2. Draw Api 추가 및 연동
3. useFormData 커스텀 훅 추가 (객체 data formData로 바꿔주는 로직)
4. useBlocker 기능 사용해 수정사항 있을때 탭을 통해 이동하는 경우 모달 띄워주기

### 🏞 스크린샷

https://github.com/user-attachments/assets/68f70390-0be8-48c8-b708-496bfdd96657


### 관련 이슈
useBlocker 기능 사용해 수정사항 있을때 탭을 통해 이동하는 경우 모달 띄워주기 기능 아직 miniQuiz에만 적용되어 있고 날짜 바꿔줄때도 막아줘야함...
=> context api로 수정했는지 안했는지 여부 관리해줘야 할까요??
