### PR TITLE
Feat/#115/drawRewardInfoApi

### DIFF
--- a/admin/src/api/probability/index.js
+++ b/admin/src/api/probability/index.js
@@ -1,0 +1,7 @@
+import { post, get, patch, put, del } from '@/api/index';
+
+const getAdminProbability = () => get(`/admin/draw-probability`);
+
+const putAdminProbability = body => put(`/admin/draw-probability`, body);
+
+export { getAdminProbability, putAdminProbability };

--- a/admin/src/api/reward/index.js
+++ b/admin/src/api/reward/index.js
@@ -1,0 +1,7 @@
+import { post, get, patch, put, del } from '@/api/index';
+
+const getAdminReward = () => get(`/admin/draw-reward-info`);
+
+const putAdminReward = body => put(`/admin/draw-reward-info`, body);
+
+export { getAdminReward, putAdminReward };

--- a/admin/src/components/header/TabHeader.jsx
+++ b/admin/src/components/header/TabHeader.jsx
@@ -3,11 +3,12 @@ import NavLinkItem from '@/components/header/NavLinkItem';
 
 function TabHeader() {
   return (
-    <div className="pt-1000 flex justify-start items-center gap-500 w-[90%]">
+    <div className="pt-1000 flex justify-between items-center w-[90%]">
       <NavLinkItem path="/" value="미니퀴즈 질문" />
       <NavLinkItem path="/miniQuizAnswer" value="미니퀴즈 답변" />
       <NavLinkItem path="/draw" value="응모 결과" />
       <NavLinkItem path="/reward" value="상품 목록" />
+      <NavLinkItem path="/probability" value="응모 당첨 확률" />
       <NavLinkItem path="/uploadReward" value="선착순 업로드" />
       <NavLinkItem path="/uploadPrize" value="경품 업로드" />
       <NavLinkItem path="/adminEventStatus" value="이벤트 현황" />

--- a/admin/src/hooks/useBeforeUnload.js
+++ b/admin/src/hooks/useBeforeUnload.js
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+const useBeforeUnload = () => {
+  useEffect(() => {
+    const handleBeforeUnload = event => {
+      event.preventDefault();
+      return (event.returnValue = '');
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  });
+};
+
+export default useBeforeUnload;

--- a/admin/src/hooks/useFormData.js
+++ b/admin/src/hooks/useFormData.js
@@ -6,8 +6,16 @@ const useFormData = () => {
 
     Object.keys(data).forEach(key => {
       if (data[key] !== undefined && data[key] !== null) {
-        console.log(data[key]);
-        formData.append(key, data[key]);
+        if (
+          typeof data[key] === 'string' &&
+          data[key].includes(
+            'https://softeer4-team8.s3.ap-northeast-2.amazonaws.com/',
+          )
+        ) {
+          // 아무것도 안함
+        } else {
+          formData.append(key, data[key]);
+        }
       }
     });
 

--- a/admin/src/hooks/useNavigationBlocker.js
+++ b/admin/src/hooks/useNavigationBlocker.js
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { useBlocker } from 'react-router-dom';
+
+const useNavigationBlocker = (
+  modified,
+  onConfirmNavigation,
+  onCancelNavigation,
+) => {
+  const [unsavedChangesModal, setUnsavedChangesModal] = useState(false);
+
+  const blocker = useBlocker(({ currentLocation, nextLocation }) => {
+    if (modified && currentLocation.pathname !== nextLocation.pathname) {
+      setUnsavedChangesModal(true);
+      return true;
+    }
+    return false;
+  });
+
+  const handleConfirmNavigation = () => {
+    setUnsavedChangesModal(false);
+    blocker.proceed();
+    if (onConfirmNavigation) onConfirmNavigation();
+  };
+
+  const handleCancelNavigation = () => {
+    setUnsavedChangesModal(false);
+    blocker.reset();
+    if (onCancelNavigation) onCancelNavigation();
+  };
+
+  return {
+    unsavedChangesModal,
+    handleConfirmNavigation,
+    handleCancelNavigation,
+  };
+};
+
+export default useNavigationBlocker;

--- a/admin/src/hooks/useRewardFormData.js
+++ b/admin/src/hooks/useRewardFormData.js
@@ -1,0 +1,34 @@
+import { useCallback } from 'react';
+
+const useRewardFormData = () => {
+  const createFormData = useCallback(data => {
+    const formData = new FormData();
+
+    data.forEach((item, index) => {
+      Object.keys(item).forEach(key => {
+        const value = item[key];
+
+        if (value !== undefined && value !== null) {
+          const formattedKey = `rewards[${index}].${key}`;
+
+          if (
+            typeof value === 'string' &&
+            value.includes(
+              'https://softeer4-team8.s3.ap-northeast-2.amazonaws.com/',
+            )
+          ) {
+            // 아무것도 안함
+          } else {
+            formData.append(formattedKey, value);
+          }
+        }
+      });
+    });
+
+    return formData;
+  }, []);
+
+  return createFormData;
+};
+
+export default useRewardFormData;

--- a/admin/src/pages/miniQuiz/MiniQuiz.jsx
+++ b/admin/src/pages/miniQuiz/MiniQuiz.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useContext, useEffect } from 'react';
-import { useNavigate, useLocation, useBlocker } from 'react-router-dom';
 import AdminEditHeader from '@/components/header/AdminEditHeader';
 import MiniQuizContent from './MiniQuizContent';
 import BlackButton from '@/components/buttons/BlackButton';
@@ -7,6 +6,8 @@ import { getAdminMiniQuiz, putAdminMiniQuiz } from '@/api/miniQuiz/index';
 import { DateContext } from '@/context/dateContext';
 import useFetch from '@/hooks/useFetch';
 import ModalFrame from '@/components/modal/ModalFrame';
+import useNavigationBlocker from '@/hooks/useNavigationBlocker';
+import useBeforeUnload from '@/hooks/useBeforeUnload';
 
 function MiniQuiz() {
   const { dateInfo } = useContext(DateContext);
@@ -18,15 +19,16 @@ function MiniQuiz() {
   } = useFetch(getAdminMiniQuiz, dateInfo);
   const [quizData, setQuizData] = useState(null);
   const [openModal, setOpenModal] = useState(false);
-  const [unsavedChangesModal, setUnsavedChangesModal] = useState(false);
   const [modified, setModified] = useState(false);
 
-  const blocker = useBlocker(({ currentLocation, nextLocation }) => {
-    if (modified && currentLocation.pathname !== nextLocation.pathname) {
-      setUnsavedChangesModal(true);
-      return true;
-    }
-    return false;
+  useBeforeUnload();
+
+  const {
+    unsavedChangesModal,
+    handleConfirmNavigation,
+    handleCancelNavigation,
+  } = useNavigationBlocker(modified, () => {
+    setModified(false);
   });
 
   useEffect(() => {
@@ -75,17 +77,6 @@ function MiniQuiz() {
       alert('수정이 불가능합니다!');
     }
     setOpenModal(false);
-  };
-
-  const handleConfirmNavigation = () => {
-    setUnsavedChangesModal(false);
-    setModified(false);
-    blocker.proceed();
-  };
-
-  const handleCancelNavigation = () => {
-    setUnsavedChangesModal(false);
-    blocker.reset();
   };
 
   if (loading) {

--- a/admin/src/pages/miniQuizAnswer/MiniQuizAnswer.jsx
+++ b/admin/src/pages/miniQuizAnswer/MiniQuizAnswer.jsx
@@ -10,6 +10,8 @@ import { DateContext } from '@/context/dateContext';
 import useFetch from '@/hooks/useFetch';
 import ModalFrame from '@/components/modal/ModalFrame';
 import useFormData from '@/hooks/useFormData';
+import useNavigationBlocker from '@/hooks/useNavigationBlocker';
+import useBeforeUnload from '@/hooks/useBeforeUnload';
 
 function MiniQuizAnswer() {
   const { dateInfo } = useContext(DateContext);
@@ -22,6 +24,17 @@ function MiniQuizAnswer() {
   const [quizAnswerData, setQuizAnswerData] = useState(null);
   const [openModal, setOpenModal] = useState(false);
   const createFormData = useFormData();
+  const [modified, setModified] = useState(false);
+
+  useBeforeUnload();
+
+  const {
+    unsavedChangesModal,
+    handleConfirmNavigation,
+    handleCancelNavigation,
+  } = useNavigationBlocker(modified, () => {
+    setModified(false);
+  });
 
   useEffect(() => {
     if (initialData) {
@@ -35,6 +48,7 @@ function MiniQuizAnswer() {
     const response = await putAdminMiniQuizAnswer(dateInfo, formData);
     if (response.status === 200) {
       await refetch();
+      setModified(false);
     } else {
       alert('수정이 불가능합니다!');
     }
@@ -54,6 +68,7 @@ function MiniQuizAnswer() {
   }
 
   const handleChange = (field, value) => {
+    setModified(true);
     setQuizAnswerData(prevState => ({
       ...prevState,
       [field]: value,
@@ -75,6 +90,13 @@ function MiniQuizAnswer() {
           text="정말 미니퀴즈 답변을 수정하실 건가요?"
           onClickNo={() => setOpenModal(false)}
           onClickYes={HandleSubmit}
+        />
+      )}
+      {unsavedChangesModal && (
+        <ModalFrame
+          text="지금 페이지를 나가시면 작성중인 내용이 삭제됩니다. 정말 페이지를 나가시겠습니까?"
+          onClickNo={handleCancelNavigation}
+          onClickYes={handleConfirmNavigation}
         />
       )}
     </div>

--- a/admin/src/pages/probability/Probability.jsx
+++ b/admin/src/pages/probability/Probability.jsx
@@ -1,0 +1,102 @@
+import React, { useState, useEffect } from 'react';
+import AdminEditHeader from '@/components/header/AdminEditHeader';
+import ProbabilityContent from './ProbabilityContent';
+import BlackButton from '@/components/buttons/BlackButton';
+import {
+  getAdminProbability,
+  putAdminProbability,
+} from '@/api/probability/index';
+import useFetch from '@/hooks/useFetch';
+import ModalFrame from '@/components/modal/ModalFrame';
+import useNavigationBlocker from '@/hooks/useNavigationBlocker';
+import useBeforeUnload from '@/hooks/useBeforeUnload';
+
+function Probability() {
+  const {
+    data: initialData,
+    loading,
+    error,
+    refetch,
+  } = useFetch(getAdminProbability);
+  const [probabilityData, setProbabilityData] = useState(null);
+  const [openModal, setOpenModal] = useState(false);
+  const [modified, setModified] = useState(false);
+
+  useBeforeUnload();
+
+  const {
+    unsavedChangesModal,
+    handleConfirmNavigation,
+    handleCancelNavigation,
+  } = useNavigationBlocker(modified, () => {
+    setModified(false);
+  });
+
+  useEffect(() => {
+    if (initialData) {
+      setProbabilityData(initialData);
+    }
+  }, [initialData]);
+
+  const handleChange = (key, value) => {
+    setModified(true);
+    setProbabilityData(prevState => ({
+      probabilities: {
+        ...prevState.probabilities,
+        [key]: Number(value),
+      },
+    }));
+  };
+
+  const handleSubmit = async () => {
+    const response = await putAdminProbability(probabilityData);
+    if (response.status === 200) {
+      await refetch();
+      setModified(false);
+    } else {
+      alert('수정이 불가능합니다!');
+    }
+    setOpenModal(false);
+  };
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  if (!probabilityData) {
+    return <div>No probability data available</div>;
+  }
+
+  return (
+    <div className="w-[100%] mt-1000">
+      <AdminEditHeader info="응모 당첨 확률 수정" />
+      <div className="flex-col w-[100%] set-center bg-neutral-white rounded-b-[10px] py-1000">
+        <ProbabilityContent
+          response={probabilityData}
+          onChange={handleChange}
+        />
+        <BlackButton value="수정하기" onClickFunc={() => setOpenModal(true)} />
+      </div>
+      {openModal && (
+        <ModalFrame
+          text="정말 응모당첨 확률을 수정하실 건가요?"
+          onClickNo={() => setOpenModal(false)}
+          onClickYes={handleSubmit}
+        />
+      )}
+      {unsavedChangesModal && (
+        <ModalFrame
+          text="지금 페이지를 나가시면 작성중인 내용이 삭제됩니다. 정말 페이지를 나가시겠습니까?"
+          onClickNo={handleCancelNavigation}
+          onClickYes={handleConfirmNavigation}
+        />
+      )}
+    </div>
+  );
+}
+
+export default Probability;

--- a/admin/src/pages/probability/ProbabilityContent.jsx
+++ b/admin/src/pages/probability/ProbabilityContent.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import InputForm from '@/components/form/InputForm';
+
+function DrawContent({ response, onChange }) {
+  return (
+    <>
+      <InputForm
+        label="응모 미당첨 확률"
+        id="0"
+        placeholder={String(response.probabilities['0'])}
+        value={String(response.probabilities['0'])}
+        onChange={value => onChange('0', value)}
+      />
+      <InputForm
+        label="2등 당첨 확률"
+        id="2"
+        placeholder={String(response.probabilities['2'])}
+        value={String(response.probabilities['2'])}
+        onChange={value => onChange('2', value)}
+      />
+      <InputForm
+        label="3등 당첨 확률"
+        id="3"
+        placeholder={String(response.probabilities['3'])}
+        value={String(response.probabilities['3'])}
+        onChange={value => onChange('3', value)}
+      />
+      <InputForm
+        label="4등 당첨 확률"
+        id="4"
+        placeholder={String(response.probabilities['4'])}
+        value={String(response.probabilities['4'])}
+        onChange={value => onChange('4', value)}
+      />
+      <InputForm
+        label="5등 당첨 확률"
+        id="5"
+        placeholder={String(response.probabilities['5'])}
+        value={String(response.probabilities['5'])}
+        onChange={value => onChange('5', value)}
+      />
+    </>
+  );
+}
+
+DrawContent.propTypes = {
+  response: PropTypes.object.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+export default DrawContent;

--- a/admin/src/pages/reward/Reward.jsx
+++ b/admin/src/pages/reward/Reward.jsx
@@ -2,76 +2,101 @@ import React, { useState, useEffect } from 'react';
 import AdminEditHeader from '@/components/header/AdminEditHeader';
 import RewardContent from './RewardContent';
 import BlackButton from '@/components/buttons/BlackButton';
+import { getAdminReward, putAdminReward } from '@/api/reward/index';
+import useFetch from '@/hooks/useFetch';
+import ModalFrame from '@/components/modal/ModalFrame';
+import useRewardFormData from '@/hooks/useRewardFormData';
+import useNavigationBlocker from '@/hooks/useNavigationBlocker';
+import useBeforeUnload from '@/hooks/useBeforeUnload';
 
 function Reward() {
-  const [rewardData, setRewardData] = useState([
-    {
-      id: 1,
-      ranking: 0,
-      name: '꽝~!',
-      stock: 5000,
-      image:
-        'https://softeer4-team8.s3.ap-northeast-2.amazonaws.com/%E1%84%8C%E1%85%A1%E1%84%8C%E1%85%A5%E1%86%AB%E1%84%80%E1%85%A5.svg',
-    },
-    {
-      id: 2,
-      ranking: 2,
-      name: '전기차 구매 보조 지원금',
-      stock: 5,
-      image:
-        'https://softeer4-team8.s3.ap-northeast-2.amazonaws.com/%E1%84%8C%E1%85%A1%E1%84%8C%E1%85%A5%E1%86%AB%E1%84%80%E1%85%A5.svg',
-    },
-    {
-      id: 3,
-      ranking: 3,
-      name: '옵션 할인 쿠폰',
-      stock: 10,
-      image:
-        'https://softeer4-team8.s3.ap-northeast-2.amazonaws.com/%E1%84%8C%E1%85%A1%E1%84%8C%E1%85%A5%E1%86%AB%E1%84%80%E1%85%A5.svg',
-    },
-    {
-      id: 4,
-      ranking: 4,
-      name: '전기차 충전 쿠폰',
-      stock: 99,
-      image:
-        'https://softeer4-team8.s3.ap-northeast-2.amazonaws.com/%E1%84%8C%E1%85%A1%E1%84%8C%E1%85%A5%E1%86%AB%E1%84%80%E1%85%A5.svg',
-    },
-    {
-      id: 5,
-      ranking: 5,
-      name: '스타벅스 커피',
-      stock: 986,
-      image:
-        'https://softeer4-team8.s3.ap-northeast-2.amazonaws.com/%E1%84%8C%E1%85%A1%E1%84%8C%E1%85%A5%E1%86%AB%E1%84%80%E1%85%A5.svg',
-    },
-  ]);
+  const {
+    data: initialData,
+    loading,
+    error,
+    refetch,
+  } = useFetch(getAdminReward);
+  const [rewardData, setRewardData] = useState([]);
+  const [openModal, setOpenModal] = useState(false);
+  const createFormData = useRewardFormData();
+  const [modified, setModified] = useState(false);
 
-  const handleChange = (id, field, value) => {
+  useBeforeUnload();
+
+  const {
+    unsavedChangesModal,
+    handleConfirmNavigation,
+    handleCancelNavigation,
+  } = useNavigationBlocker(modified, () => {
+    setModified(false);
+  });
+
+  useEffect(() => {
+    if (initialData) {
+      setRewardData(initialData.rewards);
+    }
+  }, [initialData]);
+
+  const handleChange = (index, field, value) => {
+    setModified(true);
     setRewardData(prevState =>
-      prevState.map(item =>
-        item.id === id ? { ...item, [field]: value } : item,
+      prevState.map((item, i) =>
+        i === index ? { ...item, [field]: value } : item,
       ),
     );
   };
 
   const handleSubmit = async () => {
-    // try {
-    //   const response = await axios.put(`/api/quiz/${rewardData.id}`, rewardData);
-    //   console.log('수정된 데이터가 서버에 저장되었습니다.', response.data);
-    // } catch (error) {
-    //   console.error('수정 요청 중 오류가 발생했습니다.', error);
-    // }
-    console.log('ddddd');
+    const formData = createFormData(rewardData);
+    try {
+      const response = await putAdminReward(formData);
+      if (response.status === 200) {
+        await refetch();
+        setModified(false);
+      } else {
+        alert('수정이 불가능합니다!');
+      }
+    } catch (error) {
+      console.error('Error:', error);
+      alert('서버와의 통신 중 오류가 발생했습니다.');
+    }
+
+    setOpenModal(false);
   };
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  if (!rewardData) {
+    return <div>No reward data available</div>;
+  }
 
   return (
     <div className="w-[100%] mt-1000">
       <AdminEditHeader info="상품 목록 수정" />
       <div className="flex-col w-[100%] set-center bg-neutral-100 rounded-b-[10px] py-1000">
         <RewardContent response={rewardData} onChange={handleChange} />
-        <BlackButton value="수정하기" onClickFunc={handleSubmit} />
+        <BlackButton value="수정하기" onClickFunc={() => setOpenModal(true)} />
       </div>
+      {openModal && (
+        <ModalFrame
+          text="정말 응모 결과를 수정하실 건가요?"
+          onClickNo={() => setOpenModal(false)}
+          onClickYes={handleSubmit}
+        />
+      )}
+      {unsavedChangesModal && (
+        <ModalFrame
+          text="지금 페이지를 나가시면 작성중인 내용이 삭제됩니다. 정말 페이지를 나가시겠습니까?"
+          onClickNo={handleCancelNavigation}
+          onClickYes={handleConfirmNavigation}
+        />
+      )}
     </div>
   );
 }

--- a/admin/src/pages/reward/RewardContent.jsx
+++ b/admin/src/pages/reward/RewardContent.jsx
@@ -14,36 +14,36 @@ function RewardContent({ response, onChange }) {
 
   return (
     <>
-      {response.map(item => (
+      {response.map((item, index) => (
         <div
-          key={item.id}
+          key={index} // 인덱스를 key로 사용
           className="rounded-[20px] bg-white w-[90%] shadow-xl set-center flex-col pt-1000 mb-1000"
         >
           <InputForm
             label="등수"
-            id={`ranking-${String(item.id)}`}
+            id={`ranking-${index}`}
             placeholder={String(item.ranking)}
             value={String(item.ranking)}
-            onChange={value => handleInputChange(item.id, 'ranking', value)}
+            onChange={value => handleInputChange(index, 'ranking', value)}
           />
           <InputForm
             label="이름"
-            id={`name-${String(item.id)}`}
+            id={`name-${index}`}
             placeholder={item.name}
             value={item.name}
-            onChange={value => handleInputChange(item.id, 'name', value)}
+            onChange={value => handleInputChange(index, 'name', value)}
           />
           <InputForm
             label="재고"
-            id={`stock-${String(item.id)}`}
+            id={`stock-${index}`}
             placeholder={String(item.stock)}
             value={String(item.stock)}
-            onChange={value => handleInputChange(item.id, 'stock', value)}
+            onChange={value => handleInputChange(index, 'stock', value)}
           />
           <ImageUploader
             label="이미지"
             imageUrl={item.image}
-            onChange={file => handleImageChange(item.id, file)}
+            onChange={file => handleImageChange(index, file)}
           />
         </div>
       ))}
@@ -52,15 +52,7 @@ function RewardContent({ response, onChange }) {
 }
 
 RewardContent.propTypes = {
-  response: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.number.isRequired,
-      ranking: PropTypes.number.isRequired,
-      name: PropTypes.string.isRequired,
-      stock: PropTypes.number,
-      image: PropTypes.string.isRequired,
-    }),
-  ).isRequired,
+  response: PropTypes.array.isRequired,
   onChange: PropTypes.func.isRequired,
 };
 

--- a/admin/src/router.jsx
+++ b/admin/src/router.jsx
@@ -5,6 +5,7 @@ import MiniQuiz from '@/pages/miniQuiz/MiniQuiz';
 import MiniQuizAnswer from '@/pages/miniQuizAnswer/MiniQuizAnswer';
 import Draw from '@/pages/draw/Draw';
 import Reward from '@/pages/reward/Reward';
+import Probability from '@/pages/probability/Probability';
 import AdminEventStatus from '@/pages/AdminEventStatus/AdminEventStatus';
 import UploadReward from '@/pages/UploadReward/UploadReward';
 import UploadPrize from '@/pages/UploadPrize/UploadPrize';
@@ -37,6 +38,10 @@ const router = createBrowserRouter([
           {
             path: 'reward',
             element: <Reward />,
+          },
+          {
+            path: 'probability',
+            element: <Probability />,
           },
           {
             path: 'adminEventStatus',


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- Feat/#115/drawRewardInfoApi

### 💡 작업동기
- api 연동

### 🔑 주요 변경사항
1. probability 응모 당첨 확률을 볼 수 있는 페이지 추가 및 api 연동
2. reward 경품 확인 및 수정할 수 있는 api 연동
3. useBeforeUnload 커스텀 훅 추가 및 연동
4. useBlocker 커스텀 훅 추가 및 연동
5. useRewardFormData 커스텀 훅 추가 ( reward 데이터 구조가 객체 안에 있는 배열 형식이라 useFormData 커스텀 훅 적용 불가능 )

### 🏞 스크린샷

https://github.com/user-attachments/assets/4c6531e1-9a64-49c8-957a-accffd865682




### 관련 이슈
- useBlocker랑 useBeforeUnload 커스텀 훅 각각 컴포넌트에 넣지 말고 app.js 에 넣어서 관리하는게 어떤지..? + context api 써서 변화 유무 전역적으로 관리하고 날짜 바꿀때나 주소 바꿀때 막아주는 방식이 좋을지 아니면 다른 방식이 좋을지 생각해볼 필요가 있을꺼 같습니다..!
